### PR TITLE
Implement integration tests and fix bug with response headers

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,0 +1,64 @@
+import { ApolloServer, type ApolloServerOptions, type BaseContext } from '@apollo/server';
+import { defineIntegrationTestSuite, type CreateServerForIntegrationTestsOptions } from '@apollo/server-integration-testsuite';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+import { format } from 'url';
+import { startServerAndCreateGoogleCloudFunctionsHandler } from '..';
+
+const { getTestServer } = require('@google-cloud/functions-framework/testing');
+
+describe('cloud functions handler', () => {
+  defineIntegrationTestSuite(async function (
+    serverOptions: ApolloServerOptions<BaseContext>,
+    testOptions?: CreateServerForIntegrationTestsOptions,
+  ) {
+    const apolloServer = new ApolloServer({
+      ...serverOptions,
+    });
+
+    startServerAndCreateGoogleCloudFunctionsHandler(
+      apolloServer,
+      {
+        functionTarget: 'apolloServer',
+        context: testOptions?.context,
+      }
+    );
+
+    const testServer = getTestServer('apolloServer');
+    await new Promise<void>((resolve) => {
+      testServer.listen({ port: 0 }, resolve);
+    });
+    
+    return {
+      server: apolloServer,
+      url: urlForHttpServer(testServer),
+      async extraCleanup() {
+        await new Promise<void>((resolve) => {
+          testServer.close(() => resolve());
+        });
+      },
+    }
+  }, {
+    serverIsStartedInBackground: true,
+    noIncrementalDelivery: true,
+  });
+});
+
+// Stolen from apollo server integration tests
+export function urlForHttpServer(httpServer: Server): string {
+  const { address, port } = httpServer.address() as AddressInfo;
+
+  // Convert IPs which mean "any address" (IPv4 or IPv6) into localhost
+  // corresponding loopback ip. Note that the url field we're setting is
+  // primarily for consumption by our test suite. If this heuristic is wrong for
+  // your use case, explicitly specify a frontend host (in the `host` option
+  // when listening).
+  const hostname = address === '' || address === '::' ? 'localhost' : address;
+
+  return format({
+    protocol: 'http',
+    hostname,
+    port,
+    pathname: '/',
+  });
+}

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,5 +1,8 @@
 import { ApolloServer, type ApolloServerOptions, type BaseContext } from '@apollo/server';
-import { defineIntegrationTestSuite, type CreateServerForIntegrationTestsOptions } from '@apollo/server-integration-testsuite';
+import {
+  defineIntegrationTestSuite,
+  type CreateServerForIntegrationTestsOptions,
+} from '@apollo/server-integration-testsuite';
 import type { Server } from 'http';
 import type { AddressInfo } from 'net';
 import { format } from 'url';
@@ -8,40 +11,40 @@ import { startServerAndCreateGoogleCloudFunctionsHandler } from '..';
 const { getTestServer } = require('@google-cloud/functions-framework/testing');
 
 describe('cloud functions handler', () => {
-  defineIntegrationTestSuite(async function (
-    serverOptions: ApolloServerOptions<BaseContext>,
-    testOptions?: CreateServerForIntegrationTestsOptions,
-  ) {
-    const apolloServer = new ApolloServer({
-      ...serverOptions,
-    });
+  defineIntegrationTestSuite(
+    async function (
+      serverOptions: ApolloServerOptions<BaseContext>,
+      testOptions?: CreateServerForIntegrationTestsOptions,
+    ) {
+      const apolloServer = new ApolloServer({
+        ...serverOptions,
+      });
 
-    startServerAndCreateGoogleCloudFunctionsHandler(
-      apolloServer,
-      {
+      startServerAndCreateGoogleCloudFunctionsHandler(apolloServer, {
         functionTarget: 'apolloServer',
         context: testOptions?.context,
-      }
-    );
+      });
 
-    const testServer = getTestServer('apolloServer');
-    await new Promise<void>((resolve) => {
-      testServer.listen({ port: 0 }, resolve);
-    });
-    
-    return {
-      server: apolloServer,
-      url: urlForHttpServer(testServer),
-      async extraCleanup() {
-        await new Promise<void>((resolve) => {
-          testServer.close(() => resolve());
-        });
-      },
-    }
-  }, {
-    serverIsStartedInBackground: true,
-    noIncrementalDelivery: true,
-  });
+      const testServer = getTestServer('apolloServer');
+      await new Promise<void>((resolve) => {
+        testServer.listen({ port: 0 }, resolve);
+      });
+
+      return {
+        server: apolloServer,
+        url: urlForHttpServer(testServer),
+        async extraCleanup() {
+          await new Promise<void>((resolve) => {
+            testServer.close(() => resolve());
+          });
+        },
+      };
+    },
+    {
+      serverIsStartedInBackground: true,
+      noIncrementalDelivery: true,
+    },
+  );
 });
 
 // Stolen from apollo server integration tests

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ interface Options<Context extends BaseContext> {
   functionTarget: string;
 }
 
-type GoogleCloudApiHandler = (req: Request, res: Response) => Promise<unknown> | unknown;
+export type GoogleCloudApiHandler = (req: Request, res: Response) => Promise<unknown> | unknown;
 
 const defaultContext: ContextFunction<[], any> = async () => ({});
 
@@ -59,6 +59,10 @@ export function startServerAndCreateGoogleCloudFunctionsHandler<Context extends 
         search: req.url ? parse(req.url).search || '' : '',
       },
     });
+
+    for (const [key, value] of httpGraphQLResponse.headers) {
+      res.setHeader(key, value);
+    }
 
     res.statusCode = httpGraphQLResponse.status || 200;
 


### PR DESCRIPTION
Start running the integration testsuite provided by Apollo Server.

Fix a bug surfaced by the tests where response headers weren't being set.

@ernestoresende can you take a look and cut a new patch release with this change please?