### PR TITLE
adjustments to npm publish workflow for OIDC publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,10 @@ jobs:
   publish_npm:
     name: Publish to npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     needs: [release-pr]
     if: needs.release-pr.outputs.release_created
     steps:
@@ -56,13 +60,9 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Config npm
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to npm
         run: pnpm publish --access public --no-git-checks

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/apollo-server-integrations/apollo-server-integration-google-cloud-functions"
+    "url": "git+https://github.com/apollo-server-integrations/apollo-server-integration-google-cloud-functions.git"
   },
   "homepage": "https://github.com/apollo-server-integrations/apollo-server-integration-google-cloud-functions#readme",
   "bugs": {


### PR DESCRIPTION
This PR makes changes to enable OIDC publishing to npm, so that we no longer need to use npm tokens stored in GitHub secrets.

It makes the following changes:
 * Update the `repository` field in `package.json` files to the format that `npm` expects here - via `npm pkg fix`
 * Add permissions required for OIDC publishing to the GitHub Actions workflow
 * Ensures that the node version for publishing is node 24. `npm` versions shipping with older node versions cannot publish via OIDC. Some node 22 versions can, but it's a gamble and hard to debug if something goes wrong.
 * Remove references to `NPM_TOKEN` secrets in the GitHub Actions workflow - or if using changesets, sets it to `""` as changesets requires the env var to be set, but actually doesn't do anything - and it should be empty for OIDC publishing to work.
 
 I have already gone ahead and set OIDC publishing on the npm side, so this is just the second half of the puzzle.